### PR TITLE
ノード追加時にエラーになる問題の修正

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node --max-old-space-size=384 node_modules/node-red/red.js --settings ./settings.js
+web: node --max-old-space-size=384 launch.js --settings ./settings.js

--- a/launch.js
+++ b/launch.js
@@ -1,0 +1,4 @@
+process.env.NODE_RED_HOME = __dirname
+
+require('node-red/red.js')
+


### PR DESCRIPTION
### 問題

「パレットの管理」から「ノードを追加」を選び、ノードを登録できない

### 不具合

process.env.NODE_RED_HOME が ${HOME}/node_modules/node-red/ を指しており
新しく追加したパッケージが想定外の場所に保存されてしまい登録完了を認識できない。

### 対応

起動エントリーとしている red.js のソース内には

`process.env.NODE_RED_HOME = process.env.NODE_RED_HOME | __dirname;`

という記述があるため、上記処理を通る前に process.env.NODE_RED_HOME 
の値を書き換える対応を行いました。

### 確認

「パレットの管理」から「ノードを追加」を選び、ノードを登録＆利用出来ることを確認しました。
