### PR TITLE
Update app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
   },
   "addons": [
     {
-      "plan": "heroku-postgresql:hobby-dev",
+      "plan": "heroku-postgresql:basic",
       "options": {
         "version": "12"
       }


### PR DESCRIPTION
PostgreSQLのプランが変更になり”heroku-postgresql:hobby-dev"がなくなったためデプロイが通らなかったので、デフォルトの記述を”heroku-postgresql:basic”へ変更した。それに伴い、必要に応じREADMEには有償プランである旨を記載した方が良いかもしれません。